### PR TITLE
Update docs and Dockerfile to use embedded database

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+README.md
+LICENSE
+
+Dockerfile
+docker-compose.yml
+docker-compose.yml.example
+data
+data/**

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -8,6 +8,7 @@ RUN sed -i 's|wrapper.daemonize=TRUE|wrapper.daemonize=FALSE|g' /opt/sonar/bin/l
 ADD sonarqube.conf /etc/supervisor/conf.d/sonarqube.conf
 
 EXPOSE 9000
+EXPOSE 9092
 VOLUME /data
 
 ADD start /usr/bin/start

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ database by setting the appropriate configuration variables.
 
 ```bash
 git clone https://github.com/InfoSec812/sonarqube.git
-cd **sonarqube
-docker build -t **sonarqube ./
+cd **sonarqube**
+make docker
 ```
 
 ## Database
@@ -50,6 +50,46 @@ For example, to enable Oracle as the database:
 ```bash
 docker-compose up -d
 ```
+
+By default, this container will use the embedded H2 database running on port 9092 (which you will need to export from the container). To access the embedded DB
+you will need to modify the docker-compose.yml file to expose the database port as shown below:
+
+```
+sonarqube:
+  image: infosec812/sonarqube:5.1.2
+  ports:
+    - "9000:9000"
+    - "9092:9092"
+  name:
+    - "sonarqube"
+  volumes:
+    - "/path/to/persistent/data:/data"
+  command: /usr/bin/start
+```
+
+If you want to use an external database,
+you will need to pass in the options detailed in the README.md file (below). The easiest way to accomplish this is to modify the docker-compose.yml file
+to set up the required environment variables as demonstrated below for an external PostgreSQL database. 
+
+```
+sonarqube:
+  image: infosec812/sonarqube:5.1.2
+  ports:
+    - "9000:9000"
+  name:
+    - "sonarqube"
+  environment:
+    sonar__jdbc__url: jdbc:postgresql://192.168.1.210:5432/sonar
+    sonar__jdbc__username: sonar
+    sonar__jdbc__password: sonar
+  volumes:
+    - "/path/to/persistent/data:/data"
+  command: /usr/bin/start
+```
+
+This will configure SonarQube to connect to an external PostgreSQL database with an IP address of '192.168.1.210' using the user/pass of "sonar/sonar". The database "sonar"
+will have to already have been created manually, but SonarQube will create all of the required tables and database schema.
+
 
 ## Upgrading
 

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -2,6 +2,7 @@ sonarqube:
   image: infosec812/sonarqube:5.1.2
   ports:
     - "9000:9000"
+    - "9092:9092" # Only needed when using the embedded H2 database
   name:
     - "sonarqube"
 #  environment:


### PR DESCRIPTION
Updated the Dockerfile.template so that we can expose the port for the embedded database as well as updating the README.md file to demonstrate how to use either an embedded database or an external database.
